### PR TITLE
Code plus propre, utilisation de casts statics C++

### DIFF
--- a/sbus_to_pwm_uno/sbus_to_pwm_uno.ino
+++ b/sbus_to_pwm_uno/sbus_to_pwm_uno.ino
@@ -14,7 +14,7 @@ std::array<Servo,5> g_liste_servos;
 
 void setup()
 {   
-  std::map<int,in> liste_pins_servos = { //Relation servo/pin
+  std::map<int,int> liste_pins_servos = { //Relation servo/pin
     {0,3}
     {1,5}
     {2,6}

--- a/sbus_to_pwm_uno/sbus_to_pwm_uno.ino
+++ b/sbus_to_pwm_uno/sbus_to_pwm_uno.ino
@@ -49,19 +49,18 @@ void loop(){
 }
 
 void serialEvent(void){//this function is activated by serial input, and saves sbus data in buf
-    if(Serial.available()>25){
-      while(sbus_flag==0){
-        buf[0]=Serial.read();
-        if(buf[0]==0x0f)//the sbus communication begins with 0x0f
-        {sbus_flag=1;}
-      }
-      if(sbus_flag==1){
-        for(int i=1;i<26;i++){
-          buf[i]=Serial.read();
-        }
-        sbus_flag=0;
-      }
-  }
+  //Gestion d'erreurs
+  if(Serial.available()<=25)
+    goto close_function;
+  
+  while(true)
+    if((buf[0]=Serial.read())==0x0f)//the sbus communication begins with 0x0f
+      break;
+  
+  for(int i=1;i<26;i++)
+    buf[i]=Serial.read();
+  
+  close_function:
   Sbus_Data_Count(buf);
 }
 


### PR DESCRIPTION
Utilisation d'une liste globale pour les servos au lieu de définir 5 variables isolées. Simplification de plusieurs fonctions pour une meilleur lisibilité. Utilisation des static_casts conseillés en C++ car plus performants (opération post processing)